### PR TITLE
Use Webpack for compiling; generate source maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 react-currency-masked-input.js
 npm-debug.log
+/dist

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "react": "^0.14.0"
   },
   "devDependencies": {
-    "babel": "^5.4.7",
+    "babel-core": "^6.3.26",
+    "babel-loader": "^6.2.0",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
     "babelify": "^6.1.2",
     "eslint": "^1.2.1",
     "eslint-plugin-react": "^3.2.3",
@@ -33,10 +36,11 @@
     "karma-phantomjs-launcher": "^0.2.0",
     "phantomjs": "^1.9.17",
     "react-addons-test-utils": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react-dom": "^0.14.0",
+    "webpack": "^1.12.9"
   },
   "scripts": {
-    "compile": "babel src/ --out-dir ./",
+    "compile": "webpack --config webpack.config.js",
     "lint": "eslint --ext .jsx,.js test src && jscs -x test src",
     "test": "karma start test/karma.conf.js",
     "watch": "karma start test/karma.conf.js --single-run=false",

--- a/src/react-currency-masked-input.jsx
+++ b/src/react-currency-masked-input.jsx
@@ -79,3 +79,5 @@ CurrencyMaskedInput.defaultProps = {
   value : null
 }
 
+module.exports = CurrencyMaskedInput;
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,36 @@
+var webpack = require('webpack');
+
+module.exports = {
+
+  entry: ['./src/react-currency-masked-input.jsx'],
+
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        exclude: /(node_modules|bower_components)/,
+        loader: 'babel',
+        query: {
+          presets: ['react', 'es2015']
+        }
+      }
+    ]
+  },
+
+  output: {
+    path: "./dist/",
+    library: 'CurrencyMaskedInput',
+    libraryTarget: 'var',
+    filename: 'react-currency-masked-input.js'
+  },
+
+  devtool: 'source-map',
+
+  resolve: {
+    extensions: ['', '.js', '.jsx']
+  },
+
+  externals: {
+    'react': 'React'
+  }
+};


### PR DESCRIPTION
I've been integrating CurrencyMaskedInput into an app, and along the way, I found it useful to be able to generate a source map so I could debug into the library to see what was going wrong in my setup.  To do that, I added a Webpack configuration file and set up the package.json to use it to compile the library.

I'm not sure whether or not you will find it useful as well, but here's my patch in case you do.